### PR TITLE
Adding Dashboard Card & Styling Dashboard

### DIFF
--- a/src/app/dashboard-card/dashboard-card.component.html
+++ b/src/app/dashboard-card/dashboard-card.component.html
@@ -1,0 +1,8 @@
+<div class="dashboard-card">
+    <div class="header">
+        <ng-content select="[title]"></ng-content>
+    </div>
+    <div class="body">
+        <ng-content select="[body]"></ng-content>
+    </div>
+</div>

--- a/src/app/dashboard-card/dashboard-card.component.scss
+++ b/src/app/dashboard-card/dashboard-card.component.scss
@@ -1,0 +1,36 @@
+.dashboard-card {
+    display: grid;
+    grid-template-rows: 64px 1fr;
+
+    width: 100%;
+    height: 100%;
+
+    border-radius: 8px;
+    background-color: var(--light-text);
+
+    box-shadow: 2px 4px 8px rgba(0, 0, 0, .6);
+
+    color: var(--dark-text);
+
+    box-sizing: border-box;
+
+    .header {
+        background-color: var(--light-background);
+        border-radius: 8px 8px 0px 0px;
+
+        padding: 16px;
+
+        font-size: 24px;
+        font-weight: 600;
+        line-height: 32px;
+    }
+
+    .body {
+        box-sizing: border-box;
+        padding: 16px;
+
+        height: 100%;
+    }
+
+
+}

--- a/src/app/dashboard-card/dashboard-card.component.spec.ts
+++ b/src/app/dashboard-card/dashboard-card.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DashboardCardComponent } from './dashboard-card.component';
+
+describe('DashboardCardComponent', () => {
+  let component: DashboardCardComponent;
+  let fixture: ComponentFixture<DashboardCardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DashboardCardComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(DashboardCardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/dashboard-card/dashboard-card.component.ts
+++ b/src/app/dashboard-card/dashboard-card.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-dashboard-card',
+  standalone: true,
+  imports: [],
+  templateUrl: './dashboard-card.component.html',
+  styleUrl: './dashboard-card.component.scss'
+})
+export class DashboardCardComponent {
+
+}

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -1,4 +1,4 @@
-<section>
+<section class="dashboard">
     <app-largest-earthquakes [largestEarthquakeList]="largestEarthquakeList"></app-largest-earthquakes>
     <app-top-countries></app-top-countries>
     <app-earthquakes-over-time [earthquakeCountByYear]="earthquakeCountByYear"></app-earthquakes-over-time>

--- a/src/app/dashboard/dashboard.component.scss
+++ b/src/app/dashboard/dashboard.component.scss
@@ -1,0 +1,7 @@
+.dashboard {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: 1fr 1fr;
+    column-gap: 32px;
+    row-gap: 32px;
+}

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -3,11 +3,12 @@ import { TopCountriesComponent } from '../top-countries/top-countries.component'
 import { EarthquakesOverTimeComponent } from '../earthquakes-over-time/earthquakes-over-time.component';
 import { LargestEarthquakesComponent } from '../largest-earthquakes/largest-earthquakes.component';
 import { EarthquakeCountByYear, EarthquakeExtendedWithCountry, EarthquakesService } from '../earthquakes.service';
+import { DashboardCardComponent } from '../dashboard-card/dashboard-card.component';
 
 @Component({
   selector: 'app-dashboard',
   standalone: true,
-  imports: [TopCountriesComponent, EarthquakesOverTimeComponent, LargestEarthquakesComponent],
+  imports: [TopCountriesComponent, EarthquakesOverTimeComponent, LargestEarthquakesComponent, DashboardCardComponent],
   templateUrl: './dashboard.component.html',
   styleUrl: './dashboard.component.scss'
 })

--- a/src/app/earthquakes-over-time/earthquakes-over-time.component.html
+++ b/src/app/earthquakes-over-time/earthquakes-over-time.component.html
@@ -1,7 +1,10 @@
-<section class="earthquakes-over-time">
-    <h1 class="title">Earthquakes Over Time</h1>
-    <div class="chart-area">
-        <app-line-chart [coordinates]="coordinates" yTitle="Earthquake's" xTitle="Year's"></app-line-chart>
+<app-dashboard-card>
+    <div title>Earthquakes Over Time</div>
+    <div body>
+        <section class="earthquakes-over-time">
+            <div class="chart-area">
+                <app-line-chart [coordinates]="coordinates" yTitle="Earthquake's" xTitle="Year's"></app-line-chart>
+            </div>
+        </section>
     </div>
-
-</section>
+</app-dashboard-card>

--- a/src/app/earthquakes-over-time/earthquakes-over-time.component.ts
+++ b/src/app/earthquakes-over-time/earthquakes-over-time.component.ts
@@ -3,13 +3,14 @@ import { EarthquakeCountByYear } from '../earthquakes.service';
 
 import { CommonModule } from '@angular/common';
 import { Coordinate, LineChartComponent } from '../line-chart/line-chart.component';
+import { DashboardCardComponent } from "../dashboard-card/dashboard-card.component";
 
 @Component({
   selector: 'app-earthquakes-over-time',
   standalone: true,
-  imports: [CommonModule, LineChartComponent],
   templateUrl: './earthquakes-over-time.component.html',
-  styleUrl: './earthquakes-over-time.component.scss'
+  styleUrl: './earthquakes-over-time.component.scss',
+  imports: [CommonModule, LineChartComponent, DashboardCardComponent]
 })
 export class EarthquakesOverTimeComponent {
   @Input({ required: true }) earthquakeCountByYear: Array<EarthquakeCountByYear> = []

--- a/src/app/largest-earthquakes/largest-earthquakes.component.html
+++ b/src/app/largest-earthquakes/largest-earthquakes.component.html
@@ -1,19 +1,21 @@
-<section>
-    <h1 class="title">Largest Magnitude Earthquakes</h1>
-    <div class="largest-earthquake-item">
-        <div class="header-item">Magnitude</div>
-        <div class="header-item">Date</div>
-        <div class="header-item">Country</div>
-    </div>
-    <div class="largest-earthquake-item" *ngFor="let earthquake of largestEarthquakeList">
-        <div class="magnitude">
-            {{ earthquake.magnitude }}
+<app-dashboard-card>
+    <div title>Largest Earthquakes</div>
+    <div body>
+        <div class="largest-earthquake-item">
+            <div class="header-item">Magnitude</div>
+            <div class="header-item">Date</div>
+            <div class="header-item">Country</div>
         </div>
+        <div class="largest-earthquake-item" *ngFor="let earthquake of largestEarthquakeList">
+            <div class="magnitude">
+                {{ earthquake.magnitude }}
+            </div>
 
-        <div class="date">
-            {{ earthquake.date | isoToStandard }}
+            <div class="date">
+                {{ earthquake.date | isoToStandard }}
+            </div>
+            <div class="country" *ngIf="earthquake.country">{{earthquake.country}}</div>
+            <div class="country" *ngIf="!earthquake.country">Unable to determine country</div>
         </div>
-        <div class="country" *ngIf="earthquake.country">{{earthquake.country}}</div>
-        <div class="country" *ngIf="!earthquake.country">Unable to determine country</div>
     </div>
-</section>
+</app-dashboard-card>

--- a/src/app/largest-earthquakes/largest-earthquakes.component.ts
+++ b/src/app/largest-earthquakes/largest-earthquakes.component.ts
@@ -2,13 +2,14 @@ import { Component, Input, SimpleChanges } from '@angular/core';
 import { EarthquakeExtendedWithCountry } from '../earthquakes.service';
 import { CommonModule } from '@angular/common';
 import { IsoToStandardPipe } from '../iso-to-standard.pipe';
+import { DashboardCardComponent } from "../dashboard-card/dashboard-card.component";
 
 @Component({
   selector: 'app-largest-earthquakes',
   standalone: true,
-  imports: [CommonModule, IsoToStandardPipe],
   templateUrl: './largest-earthquakes.component.html',
-  styleUrl: './largest-earthquakes.component.scss'
+  styleUrl: './largest-earthquakes.component.scss',
+  imports: [CommonModule, IsoToStandardPipe, DashboardCardComponent]
 })
 export class LargestEarthquakesComponent {
   @Input({ required: true }) largestEarthquakeList: Array<EarthquakeExtendedWithCountry> = []

--- a/src/app/line-chart/line-chart.component.ts
+++ b/src/app/line-chart/line-chart.component.ts
@@ -10,9 +10,9 @@ export interface Coordinate {
 @Component({
   selector: 'app-line-chart',
   standalone: true,
-  imports: [],
   templateUrl: './line-chart.component.html',
-  styleUrl: './line-chart.component.scss'
+  styleUrl: './line-chart.component.scss',
+  imports: []
 })
 export class LineChartComponent {
   @Input({ required: true }) coordinates!: Array<Coordinate>;

--- a/src/app/top-countries/top-countries.component.html
+++ b/src/app/top-countries/top-countries.component.html
@@ -1,14 +1,17 @@
-<div>
-    <h1>Countries With Most Earthquakes in last 10 years</h1>
-    <div *ngIf="isLoading">Loading...</div>
-    <div *ngIf="!isLoading" class="earthquakes-frequency-data">
-        <div class="frequency-entry">
-            <div class="header-item">Country</div>
-            <div class="header-item">Total Earthquakes</div>
-        </div>
-        <div class="frequency-entry" *ngFor="let item of data">
-            <div class="name">{{item.name}}</div>
-            <div class="count">{{item.count}}</div>
+<app-dashboard-card>
+    <div title>Most Earthquakes (Last 10 Years)</div>
+    <div body>
+        <div *ngIf="isLoading">Loading...</div>
+        <div *ngIf="!isLoading" class="earthquakes-frequency-data">
+            <div class="frequency-entry">
+                <div class="header-item">Country</div>
+                <div class="header-item">Total Earthquakes</div>
+            </div>
+            <div class="frequency-entry" *ngFor="let item of data">
+                <div class="name">{{item.name}}</div>
+                <div class="count">{{item.count}}</div>
+            </div>
         </div>
     </div>
-</div>
+
+</app-dashboard-card>

--- a/src/app/top-countries/top-countries.component.ts
+++ b/src/app/top-countries/top-countries.component.ts
@@ -1,13 +1,14 @@
 import { Component } from '@angular/core';
 import { CountriesService, TopEarthquakeCountry } from '../countries.service';
 import { CommonModule } from '@angular/common';
+import { DashboardCardComponent } from "../dashboard-card/dashboard-card.component";
 
 @Component({
   selector: 'app-top-countries',
   standalone: true,
-  imports: [CommonModule],
   templateUrl: './top-countries.component.html',
-  styleUrl: './top-countries.component.scss'
+  styleUrl: './top-countries.component.scss',
+  imports: [CommonModule, DashboardCardComponent]
 })
 export class TopCountriesComponent {
   data: Array<TopEarthquakeCountry> = [];


### PR DESCRIPTION
## Description:
- adding the dashboard card that defines what a standard dashboard card should look like
- using dashboard-card in all the dashboard components to ensure that the styling is consistent for each of the widgets
- adding sections for the dashboard component in the dashboard so that the components are in a grid instead of just one after the other

## Linked Issues
[Issue-1](https://github.com/bfurner27/earthquake_poc_frontend/issues/1)

## Testing
- verified that the components stay within their boundaries set by the dashboard card
- verifying that the dashboard is now split into a very basic 2x2 grid
- verifying the styling match the application themes