### PR TITLE
Complete Formatting Dashboard Widgets

### DIFF
--- a/src/app/dashboard-card/dashboard-card.component.scss
+++ b/src/app/dashboard-card/dashboard-card.component.scss
@@ -6,23 +6,22 @@
     height: 100%;
 
     border-radius: 8px;
-    background-color: var(--light-text);
-
-    box-shadow: 2px 4px 8px rgba(0, 0, 0, .6);
-
+    font-size: 20px;
     color: var(--dark-text);
 
+    box-shadow: 2px 4px 8px rgba(0, 0, 0, .6);
     box-sizing: border-box;
 
     .header {
-        background-color: var(--light-background);
         border-radius: 8px 8px 0px 0px;
-
         padding: 16px;
 
+        color: var(--light-text);
         font-size: 24px;
         font-weight: 600;
         line-height: 32px;
+
+        background-color: var(--dark-background);
     }
 
     .body {

--- a/src/app/date-formatter.service.ts
+++ b/src/app/date-formatter.service.ts
@@ -20,6 +20,10 @@ export class DateFormatterService {
     return format(date, 'MMMM dd, yyyy')
   }
 
+  formatDateStandardShort(date: Date): string {
+    return format(date, 'MMM dd, yyyy')
+  }
+
   formatDateISO(date: Date): string {
     // setting the hours to the end of the day so when it tries to convert it it remains the same day
     return format(date.setHours(23, 59, 59), 'yyyy-MM-dd');

--- a/src/app/iso-to-standard-short.pipe.spec.ts
+++ b/src/app/iso-to-standard-short.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { IsoToStandardShortPipe } from './iso-to-standard-short.pipe';
+
+describe('IsoToStandardShortPipe', () => {
+  it('create an instance', () => {
+    const pipe = new IsoToStandardShortPipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/src/app/iso-to-standard-short.pipe.ts
+++ b/src/app/iso-to-standard-short.pipe.ts
@@ -2,15 +2,16 @@ import { Pipe, PipeTransform, inject } from '@angular/core';
 import { DateFormatterService } from './date-formatter.service';
 
 @Pipe({
-  name: 'isoToStandard',
+  name: 'isoToStandardShort',
   standalone: true
 })
-export class IsoToStandardPipe implements PipeTransform {
+export class IsoToStandardShortPipe implements PipeTransform {
   constructor() { }
   private dateFormatterService: DateFormatterService = inject(DateFormatterService);
 
   transform(dateStr: string): string {
     const date = this.dateFormatterService.fromISO(dateStr)
-    return this.dateFormatterService.formatDateStandard(date)
+    return this.dateFormatterService.formatDateStandardShort(date)
   }
+
 }

--- a/src/app/largest-earthquakes/largest-earthquakes.component.html
+++ b/src/app/largest-earthquakes/largest-earthquakes.component.html
@@ -2,20 +2,20 @@
     <div title>Largest Earthquakes</div>
     <div body>
         <div class="largest-earthquake-item">
-            <div class="header-item">Magnitude</div>
-            <div class="header-item">Date</div>
-            <div class="header-item">Country</div>
+            <div class="header-item date">Date</div>
+            <div class="header-item magnitude">Mag.</div>
+            <div class="header-item country">Country</div>
         </div>
+        <div class="divider-line"></div>
         <div class="largest-earthquake-item" *ngFor="let earthquake of largestEarthquakeList">
+            <div class="date">
+                {{ earthquake.date | isoToStandardShort }}
+            </div>
             <div class="magnitude">
                 {{ earthquake.magnitude }}
             </div>
-
-            <div class="date">
-                {{ earthquake.date | isoToStandard }}
-            </div>
             <div class="country" *ngIf="earthquake.country">{{earthquake.country}}</div>
-            <div class="country" *ngIf="!earthquake.country">Unable to determine country</div>
+            <div class="country" *ngIf="!earthquake.country">N/A</div>
         </div>
     </div>
 </app-dashboard-card>

--- a/src/app/largest-earthquakes/largest-earthquakes.component.scss
+++ b/src/app/largest-earthquakes/largest-earthquakes.component.scss
@@ -4,5 +4,17 @@
     }
 
     display: grid;
-    grid-template-columns: 1fr 1fr 1fr;
+    grid-template-columns: 1fr 64px 1fr;
+
+    .country {
+        text-align: right;
+    }
+}
+
+.divider-line {
+    height: 1px;
+    width: 100%;
+    background-color: var(--dark-background);
+
+    margin: 4px 0px 8px 0px;
 }

--- a/src/app/largest-earthquakes/largest-earthquakes.component.ts
+++ b/src/app/largest-earthquakes/largest-earthquakes.component.ts
@@ -3,13 +3,14 @@ import { EarthquakeExtendedWithCountry } from '../earthquakes.service';
 import { CommonModule } from '@angular/common';
 import { IsoToStandardPipe } from '../iso-to-standard.pipe';
 import { DashboardCardComponent } from "../dashboard-card/dashboard-card.component";
+import { IsoToStandardShortPipe } from "../iso-to-standard-short.pipe";
 
 @Component({
   selector: 'app-largest-earthquakes',
   standalone: true,
   templateUrl: './largest-earthquakes.component.html',
   styleUrl: './largest-earthquakes.component.scss',
-  imports: [CommonModule, IsoToStandardPipe, DashboardCardComponent]
+  imports: [CommonModule, IsoToStandardPipe, DashboardCardComponent, IsoToStandardShortPipe]
 })
 export class LargestEarthquakesComponent {
   @Input({ required: true }) largestEarthquakeList: Array<EarthquakeExtendedWithCountry> = []

--- a/src/app/line-chart/line-chart.component.ts
+++ b/src/app/line-chart/line-chart.component.ts
@@ -53,6 +53,7 @@ export class LineChartComponent {
       title: this.title,
       font: {
         family: 'Source Sans 3',
+        size: 12,
       },
       margin: {
         t: 0,
@@ -61,17 +62,24 @@ export class LineChartComponent {
         r: 0,
       },
       xaxis: {
-        title: this.xTitle,
-        font: {
-          family: 'Source Sans 3',
+        gridcolor: '#DCF2F1',
+        title: {
+          text: this.xTitle,
+          font: {
+            family: 'Roboto'
+          }
         }
       },
       yaxis: {
-        title: this.yTitle,
-        font: {
-          family: 'Source Sans 3',
+        gridcolor: '#DCF2F1',
+        title: {
+          text: this.yTitle,
+          font: {
+            family: 'Roboto',
+          }
         }
-      }
+      },
+      colorway: ['#7FC7D9'],
     };
 
     let config = {

--- a/src/app/top-countries/top-countries.component.html
+++ b/src/app/top-countries/top-countries.component.html
@@ -3,9 +3,10 @@
     <div body>
         <div class="earthquakes-frequency-data">
             <div class="frequency-entry">
-                <div class="header-item">Country</div>
-                <div class="header-item">Total Earthquakes</div>
+                <div class="header-item name">Country</div>
+                <div class="header-item count">Total</div>
             </div>
+            <div class="divider-line"></div>
             <div class="frequency-entry" *ngFor="let item of data">
                 <div class="name">{{item.name}}</div>
                 <div class="count">{{item.count}}</div>

--- a/src/app/top-countries/top-countries.component.scss
+++ b/src/app/top-countries/top-countries.component.scss
@@ -5,6 +5,20 @@
         }
 
         display: grid;
-        grid-template-columns: 1fr 1fr 1fr;
+        grid-template-columns: 1fr 1fr;
+
+        font-size: 20px;
+
+        .count {
+            text-align: right;
+        }
+    }
+
+    .divider-line {
+        height: 1px;
+        width: 100%;
+        background-color: var(--dark-background);
+
+        margin: 4px 0px 8px 0px;
     }
 }


### PR DESCRIPTION
## Description:
- Adjusting the dashboard card header to have a dark background instead of a light background
- Adjusting the widgets to use a larger text size
- Adjusting the text colors to better match the app theme
- Adjusting the chart to use app colors instead of default colors
- Adding a line to separate header text from table content

## Issues:
- [Issue 1](https://github.com/bfurner27/earthquake_poc_frontend/issues/1)